### PR TITLE
Build changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,7 +213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -231,10 +221,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
- "anstream",
- "anstyle",
  "env_filter",
- "humantime",
  "log",
 ]
 
@@ -379,12 +366,6 @@ dependencies = [
  "match_cfg",
  "winapi",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -680,35 +661,6 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtnetlink"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ package.version = "0.6.0-dev"
 package.repository = "https://gitlab.com/xen-project/xen-guest-agent"
 package.categories = ["virtualization"]
 package.edition = "2021"
+resolver = "2"
 
 members = [
   "xen-guest-agent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ members = [
 
 [profile.release]
 lto = true
+debug = "full"

--- a/xen-guest-agent/Cargo.toml
+++ b/xen-guest-agent/Cargo.toml
@@ -10,7 +10,7 @@ license = "AGPL-3.0-only"
 futures = "0.3.26"
 tokio = { version = "1.25.0", features = ["rt", "macros", "rt-multi-thread"] }
 log = "0.4.0"
-env_logger = ">=0.10.0"
+env_logger = { version = ">=0.10.0", default-features = false }
 clap = { version = "4.4.8", features = ["derive"] }
 enum_dispatch = "0.3"
 anyhow = "1.0"

--- a/xen-guest-agent/Cargo.toml
+++ b/xen-guest-agent/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xen-guest-agent"
 version = "0.5.0-dev"
 authors = ["Yann Dirson <yann.dirson@vates.fr>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.76"
 license = "AGPL-3.0-only"
 


### PR DESCRIPTION
- Enabled debug symbols on release builds.
- `env_logger` had its features disabled by default, which excludes the entire `regex` crate from the binary, saving build time and binary size.
- Upgraded workspace to Rust 2021 and resolver v2, since all the reorganized packages are already on Rust 2021.